### PR TITLE
feat: Add agents-keepalive-loop.yml workflow

### DIFF
--- a/.github/workflows/agents-keepalive-loop.yml
+++ b/.github/workflows/agents-keepalive-loop.yml
@@ -1,0 +1,412 @@
+# CLI Codex Keepalive Loop - triggers Codex after Gate passes
+# This workflow is CRITICAL for the keepalive pipeline to function with CLI Codex.
+#
+# How it works:
+# 1. Gate workflow completes on a PR
+# 2. This workflow evaluates if keepalive should continue
+# 3. If yes, calls reusable-codex-run.yml to run Codex CLI
+# 4. Codex makes changes, pushes commits
+# 5. Gate runs again, loop continues until tasks complete
+#
+# Copy this file to: .github/workflows/agents-keepalive-loop.yml
+#
+# Required secrets:
+# - CODEX_AUTH_JSON: JSON auth for Codex CLI (ChatGPT subscription)
+# - WORKFLOWS_APP_ID: GitHub App ID (alternative to CODEX_AUTH_JSON)
+# - WORKFLOWS_APP_PRIVATE_KEY: GitHub App private key
+#
+# Required files:
+# - .github/codex/prompts/keepalive_next_task.md
+# - .github/codex/AGENT_INSTRUCTIONS.md
+name: Agents Keepalive Loop
+
+on:
+  workflow_run:
+    workflows: ["Gate"]
+    types: [completed]
+  pull_request:
+    types:
+      - labeled
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: write
+
+concurrency:
+  group: keepalive-${{ github.event.workflow_run.pull_requests[0].number || github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  evaluate:
+    name: Evaluate keepalive loop
+    runs-on: ubuntu-latest
+    environment: agent-standard
+    outputs:
+      pr_number: ${{ steps.evaluate.outputs.pr_number }}
+      pr_ref: ${{ steps.evaluate.outputs.pr_ref }}
+      head_sha: ${{ steps.evaluate.outputs.head_sha }}
+      action: ${{ steps.evaluate.outputs.action }}
+      reason: ${{ steps.evaluate.outputs.reason }}
+      gate_conclusion: ${{ steps.evaluate.outputs.gate_conclusion }}
+      iteration: ${{ steps.evaluate.outputs.iteration }}
+      max_iterations: ${{ steps.evaluate.outputs.max_iterations }}
+      failure_threshold: ${{ steps.evaluate.outputs.failure_threshold }}
+      tasks_total: ${{ steps.evaluate.outputs.tasks_total }}
+      tasks_unchecked: ${{ steps.evaluate.outputs.tasks_unchecked }}
+      keepalive_enabled: ${{ steps.evaluate.outputs.keepalive_enabled }}
+      autofix_enabled: ${{ steps.evaluate.outputs.autofix_enabled }}
+      has_agent_label: ${{ steps.evaluate.outputs.has_agent_label }}
+      agent_type: ${{ steps.evaluate.outputs.agent_type }}
+      task_appendix: ${{ steps.evaluate.outputs.task_appendix }}
+      trace: ${{ steps.evaluate.outputs.trace }}
+      start_ts: ${{ steps.timestamps.outputs.start_ts }}
+      security_blocked: ${{ steps.security_gate.outputs.blocked }}
+      security_reason: ${{ steps.security_gate.outputs.reason }}
+    steps:
+      # Dual checkout pattern: consumer repo for context, Workflows repo for scripts
+      - name: Checkout consumer repository
+        uses: actions/checkout@v4
+        with:
+          path: consumer
+
+      - name: Checkout Workflows scripts
+        uses: actions/checkout@v4
+        with:
+          repository: stranske/Workflows
+          ref: main
+          sparse-checkout: |
+            .github/scripts
+          sparse-checkout-cone-mode: false
+          path: workflows-lib
+          fetch-depth: 1
+
+      - name: Set scripts path
+        run: |
+          echo "WORKFLOWS_SCRIPTS_PATH=${GITHUB_WORKSPACE}/workflows-lib/.github/scripts" >> "$GITHUB_ENV"
+
+      - name: Capture timestamps
+        id: timestamps
+        run: echo "start_ts=$(date -u +%s)" >> "$GITHUB_OUTPUT"
+
+      - name: Security gate - prompt injection guard
+        id: security_gate
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const scriptsPath = process.env.WORKFLOWS_SCRIPTS_PATH;
+            const { evaluatePromptInjectionGuard } = require(`${scriptsPath}/prompt_injection_guard.js`);
+
+            // Resolve PR from event context
+            const payload = context.payload || {};
+            let prNumber = 0;
+            let pr = null;
+
+            if (context.eventName === 'pull_request' && payload.pull_request) {
+              prNumber = payload.pull_request.number;
+              pr = payload.pull_request;
+            } else if (context.eventName === 'workflow_run' && payload.workflow_run) {
+              const prs = payload.workflow_run.pull_requests || [];
+              if (prs[0]?.number) {
+                prNumber = prs[0].number;
+                const { data } = await github.rest.pulls.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: prNumber,
+                });
+                pr = data;
+              }
+            }
+
+            if (!pr) {
+              core.setOutput('blocked', 'false');
+              core.setOutput('reason', 'no-pr-context');
+              return;
+            }
+
+            const result = await evaluatePromptInjectionGuard({
+              github,
+              context,
+              pr,
+              actor: context.actor,
+              promptContent: pr.body || '',
+              core,
+            });
+
+            core.setOutput('blocked', String(result.blocked));
+            core.setOutput('reason', result.reason);
+
+            if (result.blocked) {
+              core.warning(`Security gate blocked: ${result.reason}`);
+            }
+
+      - name: Evaluate keepalive conditions
+        id: evaluate
+        if: steps.security_gate.outputs.blocked != 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const scriptsPath = process.env.WORKFLOWS_SCRIPTS_PATH;
+            const { evaluateKeepaliveLoop } = require(`${scriptsPath}/keepalive_loop.js`);
+
+            const result = await evaluateKeepaliveLoop({
+              github,
+              context,
+              core,
+              payload: context.payload,
+            });
+
+            const output = result.outputs || {};
+            for (const [key, value] of Object.entries(output)) {
+              core.setOutput(key, value);
+            }
+            // Task appendix needs special handling due to multiline content
+            core.setOutput('task_appendix', result.taskAppendix || '');
+
+  preflight:
+    name: Verify secrets available
+    needs: evaluate
+    if: needs.evaluate.outputs.action == 'run'
+    runs-on: ubuntu-latest
+    environment: agent-standard
+    outputs:
+      secrets_ok: ${{ steps.check.outputs.secrets_ok }}
+    steps:
+      - name: Check secrets
+        id: check
+        env:
+          HAS_CODEX_AUTH: ${{ secrets.CODEX_AUTH_JSON != '' }}
+          HAS_APP_ID: ${{ secrets.WORKFLOWS_APP_ID != '' }}
+          HAS_APP_KEY: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY != '' }}
+        run: |
+          echo "CODEX_AUTH_JSON present: $HAS_CODEX_AUTH"
+          echo "WORKFLOWS_APP_ID present: $HAS_APP_ID"
+          echo "WORKFLOWS_APP_PRIVATE_KEY present: $HAS_APP_KEY"
+          if [ "$HAS_CODEX_AUTH" = "true" ] || [ "$HAS_APP_ID" = "true" ]; then
+            echo "secrets_ok=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::Neither CODEX_AUTH_JSON nor WORKFLOWS_APP_ID is set. Cannot run Codex."
+            echo "secrets_ok=false" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+
+  # Mark agent as running before starting the actual work
+  mark-running:
+    name: Mark agent running
+    needs:
+      - evaluate
+      - preflight
+    if: needs.evaluate.outputs.action == 'run'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Workflows scripts
+        uses: actions/checkout@v4
+        with:
+          repository: stranske/Workflows
+          ref: main
+          sparse-checkout: |
+            .github/scripts
+          sparse-checkout-cone-mode: false
+          fetch-depth: 1
+
+      - name: Update summary with running status
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { markAgentRunning } = require('./.github/scripts/keepalive_loop.js');
+            const inputs = {
+              pr_number: '${{ needs.evaluate.outputs.pr_number }}',
+              agent_type: '${{ needs.evaluate.outputs.agent_type }}',
+              iteration: '${{ needs.evaluate.outputs.iteration }}',
+              max_iterations: '${{ needs.evaluate.outputs.max_iterations }}',
+              tasks_total: '${{ needs.evaluate.outputs.tasks_total }}',
+              tasks_unchecked: '${{ needs.evaluate.outputs.tasks_unchecked }}',
+              trace: '${{ needs.evaluate.outputs.trace }}',
+              run_url: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}',
+            };
+            await markAgentRunning({ github, context, core, inputs });
+
+  # Run Codex CLI for agent:codex PRs
+  run-codex:
+    name: Keepalive next task (Codex)
+    needs:
+      - evaluate
+      - preflight
+      - mark-running
+    if: needs.evaluate.outputs.agent_type == 'codex'
+    uses: stranske/Workflows/.github/workflows/reusable-codex-run.yml@main
+    secrets:
+      CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
+      WORKFLOWS_APP_ID: ${{ secrets.WORKFLOWS_APP_ID }}
+      WORKFLOWS_APP_PRIVATE_KEY: ${{ secrets.WORKFLOWS_APP_PRIVATE_KEY }}
+    with:
+      skip: ${{ needs.evaluate.outputs.action != 'run' }}
+      prompt_file: .github/codex/prompts/keepalive_next_task.md
+      mode: keepalive
+      pr_number: ${{ needs.evaluate.outputs.pr_number }}
+      pr_ref: ${{ needs.evaluate.outputs.pr_ref }}
+      appendix: ${{ needs.evaluate.outputs.task_appendix }}
+      iteration: ${{ needs.evaluate.outputs.iteration }}
+
+  summary:
+    name: Update keepalive summary
+    needs:
+      - evaluate
+      - preflight
+      - run-codex
+    if: always() && needs.evaluate.outputs.pr_number != '' && needs.evaluate.outputs.pr_number != '0'
+    runs-on: ubuntu-latest
+    environment: agent-standard
+    steps:
+      - name: Checkout Workflows scripts
+        uses: actions/checkout@v4
+        with:
+          repository: stranske/Workflows
+          ref: main
+          sparse-checkout: |
+            .github/scripts
+          sparse-checkout-cone-mode: false
+          fetch-depth: 1
+
+      - name: Emit keepalive metrics
+        id: keepalive-metrics
+        env:
+          PR_NUMBER: ${{ needs.evaluate.outputs.pr_number }}
+          ACTION: ${{ needs.evaluate.outputs.action }}
+          REASON: ${{ needs.evaluate.outputs.reason }}
+          GATE_CONCLUSION: ${{ needs.evaluate.outputs.gate_conclusion }}
+          ITERATION: ${{ needs.evaluate.outputs.iteration }}
+          MAX_ITERATIONS: ${{ needs.evaluate.outputs.max_iterations }}
+          TASKS_TOTAL: ${{ needs.evaluate.outputs.tasks_total }}
+          TASKS_UNCHECKED: ${{ needs.evaluate.outputs.tasks_unchecked }}
+          START_TS: ${{ needs.evaluate.outputs.start_ts }}
+        run: |
+          set -euo pipefail
+
+          now=$(date -u +%s)
+          if [[ "${START_TS:-}" =~ ^[0-9]+$ ]]; then
+            duration=$(( now - START_TS ))
+            if [ "$duration" -lt 0 ]; then duration=0; fi
+          else
+            duration=0
+          fi
+
+          tasks_total=${TASKS_TOTAL:-0}
+          tasks_unchecked=${TASKS_UNCHECKED:-0}
+          if ! [[ "$tasks_total" =~ ^-?[0-9]+$ ]]; then tasks_total=0; fi
+          if ! [[ "$tasks_unchecked" =~ ^-?[0-9]+$ ]]; then tasks_unchecked=0; fi
+          tasks_completed=$(( tasks_total - tasks_unchecked ))
+          if [ "$tasks_completed" -lt 0 ]; then tasks_completed=0; fi
+
+          metrics_json=$(jq -n \
+            --arg pr "${PR_NUMBER:-0}" \
+            --arg iteration "${ITERATION:-0}" \
+            --arg action "${ACTION:-}" \
+            --arg stop_reason "${REASON:-}" \
+            --arg gate_conclusion "${GATE_CONCLUSION:-}" \
+            --arg tasks_total "$tasks_total" \
+            --arg tasks_completed "$tasks_completed" \
+            --arg duration "$duration" \
+            '{
+              pr_number: ($pr | tonumber? // 0),
+              iteration_count: ($iteration | tonumber? // 0),
+              action: $action,
+              stop_reason: $stop_reason,
+              gate_conclusion: $gate_conclusion,
+              tasks_total: ($tasks_total | tonumber? // 0),
+              tasks_completed: ($tasks_completed | tonumber? // 0),
+              duration_seconds: ($duration | tonumber? // 0)
+            }')
+
+          {
+            echo '### Keepalive metrics'
+            echo ''
+            echo '| Field | Value |'
+            echo '| --- | --- |'
+            echo "| pr_number | $(echo "$metrics_json" | jq -r '.pr_number') |"
+            echo "| iteration_count | $(echo "$metrics_json" | jq -r '.iteration_count') |"
+            echo "| action | $(echo "$metrics_json" | jq -r '.action') |"
+            echo "| stop_reason | $(echo "$metrics_json" | jq -r '.stop_reason') |"
+            echo "| gate_conclusion | $(echo "$metrics_json" | jq -r '.gate_conclusion') |"
+            echo "| tasks_total | $(echo "$metrics_json" | jq -r '.tasks_total') |"
+            echo "| tasks_completed | $(echo "$metrics_json" | jq -r '.tasks_completed') |"
+            echo "| duration_seconds | $(echo "$metrics_json" | jq -r '.duration_seconds') |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          echo "$metrics_json" >> keepalive-metrics.ndjson
+
+      - name: Upload keepalive metrics artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: keepalive-metrics
+          path: keepalive-metrics.ndjson
+          retention-days: 30
+          if-no-files-found: ignore
+
+      - name: Auto-reconcile task checkboxes
+        if: needs.run-codex.outputs.changes-made == 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { autoReconcileTasks } = require('./.github/scripts/keepalive_loop.js');
+
+            const prNumber = Number('${{ needs.evaluate.outputs.pr_number }}') || 0;
+            const beforeSha = '${{ needs.evaluate.outputs.head_sha }}';
+            const headSha = '${{ needs.run-codex.outputs.commit-sha }}';
+
+            if (!prNumber || !beforeSha || !headSha) {
+              core.info('Missing required inputs for task reconciliation');
+              return;
+            }
+
+            core.info(`Auto-reconciling tasks for PR #${prNumber}`);
+            core.info(`Comparing ${beforeSha.slice(0, 7)} → ${headSha.slice(0, 7)}`);
+
+            const result = await autoReconcileTasks({
+              github, context, prNumber, baseSha: beforeSha, headSha, core
+            });
+
+            if (result.updated) {
+              core.info(`✅ ${result.details}`);
+              core.notice(`Auto-checked ${result.tasksChecked} task(s) based on commit analysis`);
+            } else {
+              core.info(`ℹ️ ${result.details}`);
+            }
+
+            core.setOutput('tasks_checked', result.tasksChecked);
+            core.setOutput('reconciliation_details', result.details);
+
+      - name: Update summary comment
+        uses: actions/github-script@v7
+        env:
+          CODEX_SUMMARY: ${{ needs.run-codex.outputs.final-message-summary || '' }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { updateKeepaliveLoopSummary } = require('./.github/scripts/keepalive_loop.js');
+            const inputs = {
+              pr_number: Number('${{ needs.evaluate.outputs.pr_number }}') || 0,
+              action: '${{ needs.evaluate.outputs.action }}',
+              reason: '${{ needs.evaluate.outputs.reason }}',
+              gate_conclusion: '${{ needs.evaluate.outputs.gate_conclusion }}',
+              iteration: Number('${{ needs.evaluate.outputs.iteration }}') || 0,
+              max_iterations: Number('${{ needs.evaluate.outputs.max_iterations }}') || 0,
+              failure_threshold: Number('${{ needs.evaluate.outputs.failure_threshold }}') || 3,
+              tasks_total: Number('${{ needs.evaluate.outputs.tasks_total }}') || 0,
+              tasks_unchecked: Number('${{ needs.evaluate.outputs.tasks_unchecked }}') || 0,
+              keepalive_enabled: '${{ needs.evaluate.outputs.keepalive_enabled }}',
+              autofix_enabled: '${{ needs.evaluate.outputs.autofix_enabled }}',
+              agent_type: '${{ needs.evaluate.outputs.agent_type }}',
+              trace: '${{ needs.evaluate.outputs.trace }}',
+              run_result: '${{ needs.run-codex.result }}',
+              agent_exit_code: '${{ needs.run-codex.outputs.exit-code }}',
+              agent_changes_made: '${{ needs.run-codex.outputs.changes-made }}',
+              agent_commit_sha: '${{ needs.run-codex.outputs.commit-sha }}',
+              agent_files_changed: '${{ needs.run-codex.outputs.files-changed }}',
+              agent_summary: process.env.CODEX_SUMMARY || '',
+            };
+            await updateKeepaliveLoopSummary({ github, context, core, inputs });


### PR DESCRIPTION
## Summary
Add the critical `agents-keepalive-loop.yml` workflow for CLI Codex keepalive.

## How it works
1. Gate workflow completes on a PR
2. This workflow evaluates if keepalive should continue  
3. If yes, calls reusable-codex-run.yml to run Codex CLI
4. Codex makes changes, pushes commits
5. Gate runs again, loop continues until tasks complete

Uses dual-checkout pattern - checks out this repo for context and stranske/Workflows for scripts.