### PR TITLE
deps: sync dev tool versions

### DIFF
--- a/.github/workflows/autofix-versions.env
+++ b/.github/workflows/autofix-versions.env
@@ -1,27 +1,17 @@
-# Pin tool versions for consistent CI behavior across all workflows
-# These versions are used by autofix, lint, and format checks
-#
-# Copy this file to: .github/workflows/autofix-versions.env
-#
-# Update these versions periodically to stay current with tooling updates.
-# The Workflows repo will notify consumer repos via repository_dispatch when
-# recommended versions change.
-
-# Python formatting and linting
+# Shared formatter/type checker pins consumed by CI workflows and local scripts.
+# Update in lock-step when bumping tooling and keep values in sync with autofix images.
 BLACK_VERSION=25.12.0
 RUFF_VERSION=0.14.10
-
-# Type checking
+ISORT_VERSION=7.0.0
+DOCFORMATTER_VERSION=1.7.7
 MYPY_VERSION=1.19.1
-
-# Testing
 PYTEST_VERSION=9.0.2
 PYTEST_COV_VERSION=7.0.0
+PYTEST_XDIST_VERSION=3.8.0
+COVERAGE_VERSION=7.13.1
+PYYAML_VERSION=6.0.2
+PYDANTIC_VERSION=2.10.3
+PYDANTIC_CORE_VERSION=2.27.1
+HYPOTHESIS_VERSION=6.115.1
+JSONSCHEMA_VERSION=4.22.0
 
-# Coverage (required by pytest-cov>=7.0.0)
-COVERAGE_VERSION=7.13.0
-
-# Pydantic (if your project uses it)
-# Uncomment and set these if you encounter pydantic-core version conflicts
-# PYDANTIC_VERSION=2.10.3
-# PYDANTIC_CORE_VERSION=2.27.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,10 +25,10 @@ dependencies = []
 
 [project.optional-dependencies]
 dev = [
-    "pytest>=8.0",
-    "pytest-cov>=4.0",
-    "ruff>=0.4",
-    "mypy>=1.10",
+    "pytest>=9.0.2",
+    "pytest-cov>=7.0.0",
+    "ruff>=0.14.10",
+    "mypy>=1.19.1",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Dev Tool Version Sync

This PR updates dev tool versions in `pyproject.toml` to match the central
version pins from [stranske/Workflows](https://github.com/stranske/Workflows).

### Changes
```
Found 4 version updates:
  - ruff: >=0.4 -> >=0.14.10
  - mypy: >=1.10 -> >=1.19.1
  - pytest: >=8.0 -> >=9.0.2
  - pytest-cov: >=4.0 -> >=7.0.0

Run with --apply to update pyproject.toml
```

### Why
Consistent dev tool versions across repos ensures:
- CI behaviors match between repos
- No surprises from version drift
- Easier debugging when tools behave the same everywhere

---
**Source:** [`.github/workflows/autofix-versions.env`](https://github.com/stranske/Workflows/blob/main/.github/workflows/autofix-versions.env)