### PR TITLE
chore: sync workflow templates

### DIFF
--- a/.github/workflows/maint-76-claude-code-review.yml
+++ b/.github/workflows/maint-76-claude-code-review.yml
@@ -188,7 +188,7 @@ jobs:
       - name: Run Claude Code Review
         id: claude
         continue-on-error: true
-        uses: anthropics/claude-code-action@24492741e0ccfdef4c1d19da8e11e0f373d07494 # v1
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: '*'


### PR DESCRIPTION
## Sync Summary

### Files Updated
- maint-76-claude-code-review.yml: Claude Code review (opt-in) - runs only on labeled PRs or manual dispatch

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- dependabot.yml: File exists and sync_mode is create_only
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Source SHA:** `8748c0b2c7e5854627469cc9073bae160c596fc7`
**Template hash:** `cb964ed998f3`
**Sync branch:** `sync/workflows-cb964ed998f3`
**Consumer repo:** `stranske/Template`
**Manifest:** `.github/sync-manifest.yml`

<!-- workflows-consumer-sync:v1 {"schema":"workflows-consumer-sync-pr/v1","consumer_repo":"stranske/Template","source_repository":"stranske/Workflows","source_sha":"8748c0b2c7e5854627469cc9073bae160c596fc7","template_hash":"cb964ed998f3","sync_branch":"sync/workflows-cb964ed998f3","manifest":".github/sync-manifest.yml","lifecycle_state":"opened","run_id":"26335570624","run_attempt":"1","changes_count":1} -->