### PR TITLE
chore: sync workflow templates

### DIFF
--- a/scripts/sync_test_dependencies.py
+++ b/scripts/sync_test_dependencies.py
@@ -182,6 +182,15 @@ def _detect_local_project_modules() -> set[str]:
             elif item.suffix == ".py":
                 detected.add(item.stem)
 
+    tests_dir = Path("tests")
+    if tests_dir.is_dir():
+        for item in tests_dir.rglob("*.py"):
+            if any(part.startswith(".") or part == "__pycache__" for part in item.parts):
+                continue
+            if item.name.startswith("test_") or item.name in {"__init__.py", "conftest.py"}:
+                continue
+            detected.add(item.stem)
+
     return detected
 
 


### PR DESCRIPTION
## Sync Summary

### Files Updated
- sync_test_dependencies.py: Syncs test dependency pins - required by reusable CI workflow

### Files Skipped
- dependabot.yml: File exists and sync_mode is create_only
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Source SHA:** `221a83f7799169d25da52aff4e26b1c82b103bd4`
**Template hash:** `2a5228d0e813`
**Sync branch:** `sync/workflows-2a5228d0e813`
**Consumer repo:** `stranske/Template`
**Manifest:** `.github/sync-manifest.yml`

<!-- workflows-consumer-sync:v1 {"schema":"workflows-consumer-sync-pr/v1","consumer_repo":"stranske/Template","source_repository":"stranske/Workflows","source_sha":"221a83f7799169d25da52aff4e26b1c82b103bd4","template_hash":"2a5228d0e813","sync_branch":"sync/workflows-2a5228d0e813","manifest":".github/sync-manifest.yml","lifecycle_state":"opened","run_id":"26832549588","run_attempt":"1","changes_count":1} -->