### PR TITLE
chore: sync workflow templates

### DIFF
--- a/tools/embedding_provider.py
+++ b/tools/embedding_provider.py
@@ -172,7 +172,7 @@ class OpenAIEmbeddingProvider(EmbeddingProvider):
         try:
             client = OpenAIEmbeddings(
                 model=resolved_model,
-                api_key=lambda: os.environ["OPENAI_API_KEY"],
+                api_key=os.environ["OPENAI_API_KEY"],
             )
             vectors = client.embed_documents(items)
         except Exception as exc:  # pragma: no cover - depends on external SDK errors


### PR DESCRIPTION
## Sync Summary

### Files Updated
- embedding_provider.py: Embedding provider registry used by synced semantic matching helpers

### Files Skipped
- dependabot.yml: File exists and sync_mode is create_only
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Source SHA:** `ee3ef5a07526baae974431e9fd40ad4a32895ed9`
**Template hash:** `248c514c8d2c`
**Sync branch:** `sync/workflows-248c514c8d2c`
**Consumer repo:** `stranske/Template`
**Manifest:** `.github/sync-manifest.yml`

<!-- workflows-consumer-sync:v1 {"schema":"workflows-consumer-sync-pr/v1","consumer_repo":"stranske/Template","source_repository":"stranske/Workflows","source_sha":"ee3ef5a07526baae974431e9fd40ad4a32895ed9","template_hash":"248c514c8d2c","sync_branch":"sync/workflows-248c514c8d2c","manifest":".github/sync-manifest.yml","lifecycle_state":"opened","run_id":"27244390955","run_attempt":"1","changes_count":1} -->