### PR TITLE
chore: sync workflow templates

### DIFF
--- a/.github/scripts/agents_pr_meta_update_body.js
+++ b/.github/scripts/agents_pr_meta_update_body.js
@@ -452,6 +452,28 @@ function resolveAgentType({ inputs = {}, env = {}, pr = {} } = {}) {
   return '';
 }
 
+function prLabelNames(pr = {}) {
+  return new Set(
+    (Array.isArray(pr.labels) ? pr.labels : [])
+      .map((label) => normalise(typeof label === 'string' ? label : label?.name))
+      .filter(Boolean),
+  );
+}
+
+function isReleasePleasePr(pr = {}) {
+  const labels = prLabelNames(pr);
+  const title = normalise(pr.title);
+  const body = normalise(pr.body);
+  const headRef = normalise(pr.head?.ref || pr.headRefName);
+
+  return (
+    headRef.startsWith('release-please--branches--') ||
+    labels.has('autorelease: pending') ||
+    /^chore\([^)]*\):\s*release\b/i.test(title) ||
+    /\brelease-please\b/i.test(body)
+  );
+}
+
 /**
  * Merge checkbox states from existingStates into newContent.
  * Only unchecked items `- [ ]` in newContent get their state restored.
@@ -1380,6 +1402,11 @@ async function run({github: rawGithub, context, core, inputs}) {
     return;
   }
 
+  if (isReleasePleasePr(pr)) {
+    core.info(`PR #${pr.number} is a release-please PR; skipping issue-sourced PR body sync.`);
+    return;
+  }
+
   const sourceContext = resolvePrSourceContext(pr);
   const issueNumber = sourceContext.issueNumber;
   if (sourceContext.noAutomation) {
@@ -1702,6 +1729,8 @@ module.exports = {
   buildPreamble,
   buildSourceContextRepairCommentBody,
   buildSourceContextResolvedCommentBody,
+  prLabelNames,
+  isReleasePleasePr,
   resolveExplicitNonIssueWorkflowSourceContext,
   extractExplicitIssueSyncNumbers,
   hasExplicitIssueSyncReference,


### PR DESCRIPTION
## Sync Summary

### Files Updated
- agents_pr_meta_update_body.js: Updates PR body with agent metadata

### Files Skipped
- renovate.json: File exists and sync_mode is create_only
- cross-repo-smoke.yml: File exists and sync_mode is create_only
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Source SHA:** `d68de1904bcdbe16bfe2462b73aa18f41f8a0a47`
**Template hash:** `cbc7a4cd85f8`
**Sync branch:** `sync/workflows-cbc7a4cd85f8`
**Consumer repo:** `stranske/Template`
**Manifest:** `.github/sync-manifest.yml`

<!-- workflows-consumer-sync:v1 {"schema":"workflows-consumer-sync-pr/v1","consumer_repo":"stranske/Template","source_repository":"stranske/Workflows","source_sha":"d68de1904bcdbe16bfe2462b73aa18f41f8a0a47","template_hash":"cbc7a4cd85f8","sync_branch":"sync/workflows-cbc7a4cd85f8","manifest":".github/sync-manifest.yml","lifecycle_state":"opened","run_id":"27836950912","run_attempt":"1","changes_count":1} -->