### PR TITLE
chore: sync workflow templates

### DIFF
--- a/.github/workflows/agents-guard.yml
+++ b/.github/workflows/agents-guard.yml
@@ -111,7 +111,7 @@ jobs:
           github.event_name == 'pull_request_target' &&
           steps.eligibility.outputs.should-run == 'true' &&
           steps.api_client_base.outputs.available != 'true'
-        uses: "stranske/Workflows/.github/actions/setup-api-client@a335f1af2c35b8f35d2278f56e9af78792a09bf1" # v1
+        uses: "stranske/Workflows/.github/actions/setup-api-client@6c3391d38bbc20a4577ac42b9aa6c9dc4e462c09" # v1
         with:
           secrets: ${{ toJSON(secrets) }}
           github_token: ${{ github.token }}
@@ -180,7 +180,7 @@ jobs:
           steps.eligibility.outputs.should-run == 'true' &&
           github.event_name == 'pull_request' &&
           steps.api_client_head.outputs.available != 'true'
-        uses: "stranske/Workflows/.github/actions/setup-api-client@a335f1af2c35b8f35d2278f56e9af78792a09bf1" # v1
+        uses: "stranske/Workflows/.github/actions/setup-api-client@6c3391d38bbc20a4577ac42b9aa6c9dc4e462c09" # v1
         with:
           secrets: ${{ toJSON(secrets) }}
           github_token: ${{ github.token }}


### PR DESCRIPTION
## Sync Summary

### Files Updated
- agents-guard.yml: Agents guard - enforces agents workflow protections (Health 45)

### Files Skipped
- renovate.json: File exists and sync_mode is create_only
- cross-repo-smoke.yml: File exists and sync_mode is create_only
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Source SHA:** `56350f8170508a46e484c295404c47a75c9e2db0`
**Template hash:** `db755a28c753`
**Sync branch:** `sync/workflows-db755a28c753`
**Consumer repo:** `stranske/Template`
**Manifest:** `.github/sync-manifest.yml`

<!-- workflows-consumer-sync:v1 {"schema":"workflows-consumer-sync-pr/v1","consumer_repo":"stranske/Template","source_repository":"stranske/Workflows","source_sha":"56350f8170508a46e484c295404c47a75c9e2db0","template_hash":"db755a28c753","sync_branch":"sync/workflows-db755a28c753","manifest":".github/sync-manifest.yml","lifecycle_state":"opened","run_id":"28045152994","run_attempt":"1","changes_count":1} -->