### PR TITLE
chore: sync workflow templates

### DIFF
--- a/tools/llm_registry.py
+++ b/tools/llm_registry.py
@@ -118,6 +118,21 @@ def load_model_registry() -> list[ModelRegistryEntry]:
     return entries
 
 
+def _model_registry_format_valid() -> bool:
+    config_path = os.environ.get(ENV_MODEL_REGISTRY_CONFIG)
+    path = Path(config_path) if config_path else DEFAULT_MODEL_REGISTRY_CONFIG_PATH
+    if not path.is_file():
+        return True
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    if not isinstance(payload, dict):
+        return False
+    raw_models = payload.get("models", [])
+    return isinstance(raw_models, list)
+
+
 def registry_entry_for(
     provider: str, model: str, registry: list[ModelRegistryEntry] | None = None
 ) -> ModelRegistryEntry | None:
@@ -228,10 +243,18 @@ def load_slot_config(*, github_default_model: str) -> list[SlotDefinition]:
         return fallback_slots
 
     registry = load_model_registry()
+    slot_entries = _slot_entries(payload, path)
+    if not _model_registry_format_valid() and any(
+        str(entry.get("provider", "")).strip()
+        and not str(entry.get("model", "")).strip()
+        and str(entry.get("quality_tier") or entry.get("tier") or "").strip()
+        for entry in slot_entries
+    ):
+        return fallback_slots
     slots: list[SlotDefinition] = []
     fallback_by_position = dict(enumerate(fallback_slots, start=1))
     fallback_by_provider = {slot.provider: slot for slot in fallback_slots}
-    for idx, entry in enumerate(_slot_entries(payload, path), start=1):
+    for idx, entry in enumerate(slot_entries, start=1):
         provider = normalize_provider(str(entry.get("provider", "")))
         model = str(entry.get("model", "")).strip()
         tier = str(entry.get("quality_tier") or entry.get("tier") or "").strip()


### PR DESCRIPTION
## Sync Summary

### Files Updated
- llm_registry.py: LLM model registry helper - shared slot/model selection and blocked-model enforcement

### Files Skipped
- renovate.json: File exists and sync_mode is create_only
- cross-repo-smoke.yml: File exists and sync_mode is create_only
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Source SHA:** `5c689341791a5670409067cbc386fdefbfa2d8bf`
**Template hash:** `ece69764221a`
**Sync branch:** `sync/workflows-ece69764221a`
**Consumer repo:** `stranske/Template`
**Manifest:** `.github/sync-manifest.yml`

<!-- workflows-consumer-sync:v1 {"schema":"workflows-consumer-sync-pr/v1","consumer_repo":"stranske/Template","source_repository":"stranske/Workflows","source_sha":"5c689341791a5670409067cbc386fdefbfa2d8bf","template_hash":"ece69764221a","sync_branch":"sync/workflows-ece69764221a","manifest":".github/sync-manifest.yml","lifecycle_state":"opened","run_id":"28455998925","run_attempt":"1","changes_count":1} -->