### PR TITLE
deps: sync dev tool versions

### DIFF
--- a/.github/workflows/autofix-versions.env
+++ b/.github/workflows/autofix-versions.env
@@ -5,11 +5,11 @@
 # Runtime dependencies (PyYAML, Pydantic, Hypothesis) should be managed via Dependabot
 # in each consumer repo's pyproject.toml directly, NOT synced from this file.
 BLACK_VERSION=26.5.1
-RUFF_VERSION=0.15.20
+RUFF_VERSION=0.15.22
 ISORT_VERSION=8.0.1
 DOCFORMATTER_VERSION=1.7.8
-MYPY_VERSION=2.1.0
+MYPY_VERSION=2.3.0
 PYTEST_VERSION=9.1.1
 PYTEST_COV_VERSION=7.1.0
 PYTEST_XDIST_VERSION=3.8.0
-COVERAGE_VERSION=7.15.1
+COVERAGE_VERSION=7.15.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,9 +26,9 @@ dependencies = []
 dev = [
     "pytest==9.1.1",
     "pytest-cov==7.1.0",
-    "ruff==0.15.20",
-    "mypy>=2.1.0",
-    "black>=26.5.1",
+    "ruff==0.15.22",
+    "mypy==2.3.0",
+    "black==26.5.1",
 ]
 
 [project.urls]

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -2,17 +2,17 @@
 #    uv pip compile pyproject.toml --extra dev --output-file requirements-dev.lock
 ast-serialize==0.3.0
     # via mypy
-black==26.3.1
+black==26.5.1
     # via my-project (pyproject.toml)
 click==8.3.1
     # via black
-coverage==7.14.0
+coverage==7.15.2
     # via pytest-cov
 iniconfig==2.3.0
     # via pytest
 librt==0.11.0
     # via mypy
-mypy==2.1.0
+mypy==2.3.0
     # via my-project (pyproject.toml)
 mypy-extensions==1.1.0
     # via
@@ -34,7 +34,7 @@ pluggy==1.6.0
     #   pytest-cov
 pygments==2.19.2
     # via pytest
-pytest==9.0.3
+pytest==9.1.1
     # via
     #   my-project (pyproject.toml)
     #   pytest-cov
@@ -42,7 +42,7 @@ pytest-cov==7.1.0
     # via my-project (pyproject.toml)
 pytokens==0.4.1
     # via black
-ruff==0.15.13
+ruff==0.15.22
     # via my-project (pyproject.toml)
 typing-extensions==4.15.0
     # via mypy

--- a/requirements.lock
+++ b/requirements.lock
@@ -10,13 +10,13 @@ colorama==0.4.6 ; sys_platform == 'win32'
     # via
     #   click
     #   pytest
-coverage==7.15.1
+coverage==7.15.2
     # via pytest-cov
 iniconfig==2.3.0
     # via pytest
 librt==0.12.0 ; platform_python_implementation != 'PyPy'
     # via mypy
-mypy==2.1.0
+mypy==2.3.0
     # via my-project (pyproject.toml)
 mypy-extensions==1.1.0
     # via
@@ -46,7 +46,7 @@ pytest-cov==7.1.0
     # via my-project (pyproject.toml)
 pytokens==0.4.1
     # via black
-ruff==0.15.20
+ruff==0.15.22
     # via my-project (pyproject.toml)
 typing-extensions==4.16.0
     # via mypy


### PR DESCRIPTION
## Dev Tool Version Sync

This PR updates dev tool versions in `pyproject.toml` and related generated dependency files to match the central version pins from [stranske/Workflows](https://github.com/stranske/Workflows).

### Changes
```
Found 11 version updates:
  - ruff: ==0.15.20 -> ==0.15.22
  - black: >=26.5.1 -> ==26.5.1
  - mypy: >=2.1.0 -> ==2.3.0
  - requirements.lock:coverage: 7.15.1 -> ==7.15.2
  - requirements.lock:mypy: 2.1.0 -> ==2.3.0
  - requirements.lock:ruff: 0.15.20 -> ==0.15.22
  - requirements-dev.lock:black: 26.3.1 -> ==26.5.1
  - requirements-dev.lock:coverage: 7.14.0 -> ==7.15.2
  - requirements-dev.lock:mypy: 2.1.0 -> ==2.3.0
  - requirements-dev.lock:pytest: 9.0.3 -> ==9.1.1
  - requirements-dev.lock:ruff: 0.15.13 -> ==0.15.22

Run with --apply to update dependency files
```

### Why
Consistent dev tool versions across repos ensures:
- CI behaviors match between repos
- No surprises from version drift
- Easier debugging when tools behave the same everywhere

---
**Source:** `.github/workflows/autofix-versions.env`