### PR TITLE
chore: sync workflow templates

### DIFF
--- a/.github/scripts/keepalive_loop.js
+++ b/.github/scripts/keepalive_loop.js
@@ -801,8 +801,12 @@ function buildMetricsRecord({
   const capabilityResult = capabilityBundles && typeof capabilityBundles === 'object'
     ? capabilityBundles
     : { applied: [], rejected: [] };
-  const applied = Array.isArray(capabilityResult.applied) ? capabilityResult.applied : [];
-  const rejected = Array.isArray(capabilityResult.rejected) ? capabilityResult.rejected : [];
+  const applied = Array.isArray(capabilityResult.applied)
+    ? capabilityResult.applied.filter((bundle) => bundle && typeof bundle === 'object' && !Array.isArray(bundle))
+    : [];
+  const rejected = Array.isArray(capabilityResult.rejected)
+    ? capabilityResult.rejected.filter((bundle) => bundle && typeof bundle === 'object' && !Array.isArray(bundle))
+    : [];
   return {
     pr_number: toNumber(prNumber, 0),
     iteration: Math.max(1, toNumber(iteration, 0)),

--- a/tools/llm_registry.py
+++ b/tools/llm_registry.py
@@ -357,18 +357,25 @@ def load_slot_config(*, github_default_model: str = "") -> list[SlotDefinition]:
         ):
             model = explicit_model
         elif provider and explicit_model and explicit_model != model:
-            logger.warning(
-                "Skipping unresolved slot model pin %s/%s; reviewed %s selection is %s",
+            # A caller-supplied slot file is an allowlist and must fail closed.
+            # The repository's bundled legacy file is advisory: ignore a stale
+            # pin and retain the reviewed registry selection for that provider.
+            if os.environ.get(ENV_SLOT_CONFIG):
+                logger.warning(
+                    "Skipping unresolved slot model pin %s/%s; reviewed %s selection is %s",
+                    provider,
+                    explicit_model,
+                    profile,
+                    model or "unavailable",
+                )
+                continue
+            logger.debug(
+                "Ignoring advisory bundled slot model pin %s/%s; reviewed %s selection is %s",
                 provider,
                 explicit_model,
                 profile,
                 model or "unavailable",
             )
-            # A caller-supplied slot file is an allowlist and must fail closed.
-            # The repository's bundled legacy file is advisory: ignore a stale
-            # pin and retain the reviewed registry selection for that provider.
-            if os.environ.get(ENV_SLOT_CONFIG):
-                continue
         if provider and configured_profile and not model:
             logger.warning(
                 "Skipping slot with unresolved reviewed profile: %s/%s",


### PR DESCRIPTION
## Sync Summary

### Files Updated
- keepalive_loop.js: Core keepalive loop logic
- llm_registry.py: LLM model registry helper - shared slot/model selection and blocked-model enforcement

### Files Skipped
- renovate.json: File exists and sync_mode is create_only
- cross-repo-smoke.yml: File exists and sync_mode is create_only
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Source SHA:** `f2d175db81336e9c314c9d1ec82260512ff5cf09`
**Template hash:** `08710847d73d`
**Sync branch:** `sync/workflows-08710847d73d`
**Consumer repo:** `stranske/Template`
**Manifest:** `.github/sync-manifest.yml`

<!-- workflows-consumer-sync:v1 {"schema":"workflows-consumer-sync-pr/v1","consumer_repo":"stranske/Template","source_repository":"stranske/Workflows","source_sha":"f2d175db81336e9c314c9d1ec82260512ff5cf09","template_hash":"08710847d73d","sync_branch":"sync/workflows-08710847d73d","manifest":".github/sync-manifest.yml","lifecycle_state":"opened","run_id":"29706159915","run_attempt":"1","changes_count":2} -->