### PR TITLE
chore: sync workflow templates

### DIFF
--- a/tools/llm_registry.py
+++ b/tools/llm_registry.py
@@ -133,7 +133,6 @@ def load_model_registry() -> list[ModelRegistryEntry]:
                 model=model,
                 blocked=bool(raw_entry.get("blocked", False)),
                 lifecycle=str(raw_entry.get("lifecycle", "unknown")).strip().lower(),
-                quality={},
             )
         )
     return entries
@@ -370,7 +369,7 @@ def load_slot_config(*, github_default_model: str = "") -> list[SlotDefinition]:
                 )
                 continue
             logger.debug(
-                "Ignoring advisory bundled slot model pin %s/%s; reviewed %s selection is %s",
+                "Ignoring advisory bundled slot model pin %s/%s; reviewed %s selection before fallback is %s",
                 provider,
                 explicit_model,
                 profile,
@@ -435,7 +434,12 @@ def resolve_slots(
     # Preserve an explicit runtime override as an emergency bootstrap when the
     # registry file is unavailable. Empty models are never invoked directly;
     # langchain_client skips them when the override cannot serve that provider.
-    if not slots and not os.environ.get(ENV_SLOT_CONFIG) and os.environ.get(env_model_name):
+    if (
+        not slots
+        and not os.environ.get(ENV_SLOT_CONFIG)
+        and not _slot_path().exists()
+        and os.environ.get(env_model_name)
+    ):
         slots = [
             SlotDefinition(name=f"slot{index}", provider=provider, model="")
             for index, provider in enumerate(


### PR DESCRIPTION
## Sync Summary

### Files Updated
- llm_registry.py: LLM model registry helper - shared slot/model selection and blocked-model enforcement

### Files Skipped
- renovate.json: File exists and sync_mode is create_only
- cross-repo-smoke.yml: File exists and sync_mode is create_only
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Source SHA:** `57a384d958a5fbff23aa3b2c9ec9780ac8c95bb3`
**Template hash:** `2bf99d6e725c`
**Sync branch:** `sync/workflows-2bf99d6e725c`
**Consumer repo:** `stranske/Template`
**Manifest:** `.github/sync-manifest.yml`

<!-- workflows-consumer-sync:v1 {"schema":"workflows-consumer-sync-pr/v1","consumer_repo":"stranske/Template","source_repository":"stranske/Workflows","source_sha":"57a384d958a5fbff23aa3b2c9ec9780ac8c95bb3","template_hash":"2bf99d6e725c","sync_branch":"sync/workflows-2bf99d6e725c","manifest":".github/sync-manifest.yml","lifecycle_state":"opened","run_id":"29717000368","run_attempt":"1","changes_count":1} -->