### PR TITLE
deps: sync dev tool versions

### DIFF
--- a/.github/workflows/autofix-versions.env
+++ b/.github/workflows/autofix-versions.env
@@ -5,7 +5,7 @@
 # Runtime dependencies (PyYAML, Pydantic, Hypothesis) should be managed via Dependabot
 # in each consumer repo's pyproject.toml directly, NOT synced from this file.
 BLACK_VERSION=26.5.1
-RUFF_VERSION=0.16.1
+RUFF_VERSION=0.16.2
 ISORT_VERSION=8.0.1
 DOCFORMATTER_VERSION=1.7.8
 MYPY_VERSION=2.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = []
 dev = [
     "pytest==9.1.1",
     "pytest-cov==7.1.0",
-    "ruff==0.16.1",
+    "ruff==0.16.2",
     "mypy==2.3.0",
     "black==26.5.1",
 ]

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -42,7 +42,7 @@ pytest-cov==7.1.0
     # via my-project (pyproject.toml)
 pytokens==0.4.1
     # via black
-ruff==0.16.1
+ruff==0.16.2
     # via my-project (pyproject.toml)
 typing-extensions==4.15.0
     # via mypy

--- a/requirements.lock
+++ b/requirements.lock
@@ -46,7 +46,7 @@ pytest-cov==7.1.0
     # via my-project (pyproject.toml)
 pytokens==0.4.1
     # via black
-ruff==0.16.1
+ruff==0.16.2
     # via my-project (pyproject.toml)
 typing-extensions==4.16.0
     # via mypy


### PR DESCRIPTION
## Dev Tool Version Sync

This PR updates dev tool versions in `pyproject.toml` and related generated dependency files to match the central version pins from [stranske/Workflows](https://github.com/stranske/Workflows).

### Changes
```
Found 3 version updates:
  - ruff: ==0.16.1 -> ==0.16.2
  - requirements.lock:ruff: 0.16.1 -> ==0.16.2
  - requirements-dev.lock:ruff: 0.16.1 -> ==0.16.2

Run with --apply to update dependency files
```

### Why
Consistent dev tool versions across repos ensures:
- CI behaviors match between repos
- No surprises from version drift
- Easier debugging when tools behave the same everywhere

---
**Source:** `.github/workflows/autofix-versions.env`
**Settled source commit:** `fce14d49cbd3dd6e68598edda4eacc01fbfa95c4`

<!-- sync-pr-delivery-record:v1 {"schema":"sync-pr-delivery-record/v1","durable_issue_url":"https://github.com/stranske/Workflows/issues/1836","plan_id":"dev-tool-69b135912235","generation":"69b135912235","repository":"stranske/Template","desired_tree_hash":"f6dc171a99f9102c52569ee3525eefaa2a935f7e","source_commit":"fce14d49cbd3dd6e68598edda4eacc01fbfa95c4","lease_expires_at":"2026-08-11T01:09:08Z","predecessor_prs":[],"successor_prs":[]} -->