### PR TITLE
chore: sync workflow templates

### DIFF
--- a/.github/scripts/issue_format.py
+++ b/.github/scripts/issue_format.py
@@ -199,6 +199,33 @@ def _section_text(body: str, start: int) -> str:
     return "\n".join(lines[start + 1 : end])
 
 
+def _without_fenced_code(text: str) -> str:
+    """Remove Markdown fences so examples cannot satisfy issue requirements."""
+    kept: list[str] = []
+    fence: tuple[str, int] | None = None
+    for line in text.splitlines():
+        match = re.match(r"\s{0,3}(`{3,}|~{3,})", line)
+        if match:
+            marker = match.group(1)
+            if fence is None:
+                fence = (marker[0], len(marker))
+            elif (
+                marker[0] == fence[0]
+                and len(marker) >= fence[1]
+                and re.fullmatch(
+                    rf"\s{{0,3}}(?:`{{{fence[1]},}}|~{{{fence[1]},}})\s*",
+                    line,
+                )
+            ):
+                # Closing fences are marker-only (optional whitespace); trailing
+                # content such as a language tag must not end the fence.
+                fence = None
+            continue
+        if fence is None:
+            kept.append(line)
+    return "\n".join(kept)
+
+
 @dataclass
 class Report:
     ok: bool = True
@@ -247,7 +274,9 @@ def validate(body: str) -> Report:
     tasks_at = _find(body, REQUIRED["Tasks"])
     if tasks_at is not None:
         task_items = re.findall(
-            r"^\s*[-*]\s*\[[ xX]\]\s*(.+)$", _section_text(body, tasks_at), re.M
+            r"^\s*[-*]\s*\[[ xX]\]\s*(.+)$",
+            _without_fenced_code(_section_text(body, tasks_at)),
+            re.M,
         )
         if not task_items:
             report.problems.append(
@@ -260,7 +289,7 @@ def validate(body: str) -> Report:
 
     acceptance_at = _find(body, REQUIRED["Acceptance Criteria"])
     if acceptance_at is not None:
-        acceptance = _section_text(body, acceptance_at)
+        acceptance = _without_fenced_code(_section_text(body, acceptance_at))
         if not GATE.search(acceptance):
             report.problems.append(
                 "`Acceptance Criteria` names no test, runnable command or observable "

--- a/.github/scripts/source_context.js
+++ b/.github/scripts/source_context.js
@@ -368,16 +368,25 @@ function inferredSourceType(pull = {}) {
   if (author.startsWith('dependabot') || branch.startsWith('dependabot/')) {
     return SOURCE_TYPES.DEPENDABOT;
   }
-  if (
-    branch.startsWith('sync/') ||
-    branch.startsWith('sync-') ||
-    labels.includes('campaign:sync-dependabot') ||
-    /\bsync\b/.test(title)
-  ) {
+  if (branch.startsWith('sync/') || branch.startsWith('sync-')) {
+    return SOURCE_TYPES.SYNC_CAMPAIGN;
+  }
+  if (labels.includes('campaign:sync-dependabot')) {
+    return SOURCE_TYPES.SYNC_CAMPAIGN;
+  }
+  if (author === 'github-actions[bot]' || author === 'github-actions') {
+    return SOURCE_TYPES.AUTOMATION_RUN;
+  }
+  if (/\bsync\b/.test(title)) {
     return SOURCE_TYPES.SYNC_CAMPAIGN;
   }
   if (/review[-/ ]follow/.test(branch) || /\breview\s+follow[- ]?up\b/.test(title)) {
     return SOURCE_TYPES.REVIEW_FOLLOWUP;
+  }
+  if ([
+    'feat/', 'fix/', 'docs/', 'audit/', 'chore/', 'refactor/', 'perf/', 'test/',
+  ].some((prefix) => branch.startsWith(prefix))) {
+    return SOURCE_TYPES.LOCAL_REQUEST;
   }
   return SOURCE_TYPES.UNKNOWN;
 }

--- a/.github/workflows/agents-auto-pilot.yml
+++ b/.github/workflows/agents-auto-pilot.yml
@@ -795,8 +795,14 @@ jobs:
               with open('/tmp/guard_blocked', 'w') as f:
                   f.write(reason)
               sys.exit(0)
+          if result.get('error'):
+              print('ERROR: Formatter failed: ' + str(result.get('error')))
+              sys.exit(1)
           if result.get('needs_refinement'):
               reason = 'Formatter output does not satisfy the canonical issue-format contract.'
+              audit = result.get('validation_audit')
+              if audit:
+                  reason += '\nvalidation_audit=' + json.dumps(audit, sort_keys=True)
               print(f'NEEDS_REFINEMENT: {reason}')
               with open('/tmp/needs_refinement', 'w') as f:
                   f.write(reason)

--- a/.github/workflows/agents-issue-format-guard.yml
+++ b/.github/workflows/agents-issue-format-guard.yml
@@ -269,10 +269,10 @@ jobs:
               || echo "::warning::could not apply agents:auto-pilot-pause"
             gh issue edit "$NUMBER" --repo "$GITHUB_REPOSITORY" --remove-label "agents:format" \
               || echo "::warning::could not release agents:format after attempt cap"
-            gh issue comment "$NUMBER" --repo "$GITHUB_REPOSITORY" --body-file - <<EOF
-          <!-- format-guard:attempt-cap -->
-          Automated formatting stopped after $format_guard_attempts optimizer attempts. Fix the issue body manually, then remove agents:auto-pilot-pause before retrying.
-          EOF
+            printf '%s\n' \
+              '<!-- format-guard:attempt-cap -->' \
+              "Automated formatting stopped after $format_guard_attempts optimizer attempts. Fix the issue body manually, then remove agents:auto-pilot-pause before retrying." \
+              | gh issue comment "$NUMBER" --repo "$GITHUB_REPOSITORY" --body-file -
             exit 0
           fi
           has_format_label=false

--- a/.github/workflows/agents-issue-intake.yml
+++ b/.github/workflows/agents-issue-intake.yml
@@ -114,7 +114,8 @@ jobs:
        (github.event.issue.state != 'closed' &&
         (contains(toJson(github.event.issue.labels.*.name), 'agent:') ||
          contains(toJson(github.event.issue.labels.*.name), 'agents:')))) &&
-      !contains(github.event.issue.labels.*.name, 'agents:auto-pilot')
+      (github.event_name != 'issues' ||
+      !contains(github.event.issue.labels.*.name, 'agents:auto-pilot'))
     runs-on: ubuntu-latest
     outputs:
       should_run: ${{ steps.check.outputs.should_run }}

--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -123,7 +123,7 @@ def _explicit_marker(section: str) -> DeliberateBreakSpec | None:
     return None
 
 
-def _fallback_marker(section: str) -> DeliberateBreakSpec | None:
+def _fallback_marker(section: str, markdown: str = "") -> DeliberateBreakSpec | None:
     named_line = next(
         (line for line in section.splitlines() if "named test:" in line.lower()),
         "",
@@ -140,20 +140,56 @@ def _fallback_marker(section: str) -> DeliberateBreakSpec | None:
         return None
 
     test_file_match = re.search(r"`([^`]*(?:test|tests)[^`]*\.py)`", named_line)
-    test_name_match = re.search(r"\bwith\s+`?([A-Za-z_][A-Za-z0-9_]*)`?", named_line)
-    break_file_match = re.search(r"`([^`]+)`", break_line)
-    if not test_file_match or not test_name_match or not break_file_match:
+    test_name_match = (
+        re.search(r"\btest\s+`([^`]+)`", named_line)
+        or re.search(r"\bwith\s+`([^`]+)`", named_line)
+        or re.search(r"\bwith\s+`?([A-Za-z_][A-Za-z0-9_]*)`?", named_line)
+    )
+    break_file = _infer_break_file(break_line, named_line, markdown)
+    if not test_file_match or not test_name_match or not break_file:
         return None
 
     test_file = test_file_match.group(1)
     test_id = f"{test_file}::{test_name_match.group(1)}"
-    break_file = break_file_match.group(1)
     return DeliberateBreakSpec(test_id, test_file, break_file, _pytest_command(test_id))
+
+
+def _infer_break_file(break_line: str, named_line: str, markdown: str) -> str | None:
+    """Pick a revert target from acceptance wording, skipping label-like backticks."""
+
+    def _candidate_paths(text: str) -> list[str]:
+        paths: list[str] = []
+        for path in re.findall(r"`([^`]+)`", text):
+            normalized = path.strip().rstrip(":")
+            if not normalized:
+                continue
+            if re.fullmatch(r"[A-Za-z][\w-]*:\s*.+", normalized):
+                continue
+            if re.search(r"\s", normalized):
+                continue
+            path_only = normalized.split(":", 1)[0]
+            if "/" in path_only or path_only.endswith((".py", ".yml", ".yaml", ".js")):
+                paths.append(path_only)
+        return paths
+
+    ordered_paths: list[str] = []
+    for text in (break_line, named_line, markdown):
+        ordered_paths.extend(_candidate_paths(text))
+
+    workflow_paths = [
+        path
+        for path in ordered_paths
+        if ".github/workflows/" in path or path.endswith((".yml", ".yaml"))
+    ]
+    if workflow_paths:
+        return workflow_paths[0]
+
+    return ordered_paths[0] if ordered_paths else None
 
 
 def parse_deliberate_break_spec(markdown: str) -> DeliberateBreakSpec | None:
     section = _acceptance_criteria(markdown)
-    return _explicit_marker(section) or _fallback_marker(section)
+    return _explicit_marker(section) or _fallback_marker(section, markdown)
 
 
 def _pytest_command(test_id: str) -> tuple[str, ...]:

--- a/scripts/langchain/issue_formatter.py
+++ b/scripts/langchain/issue_formatter.py
@@ -58,7 +58,13 @@ def _issue_format_validator() -> Any:
         raise RuntimeError(f"Cannot load canonical issue-format validator: {validator_path}")
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
-    spec.loader.exec_module(module)
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        # Do not leave a half-initialized validator behind: callers retry this
+        # loader after transient consumer-sync failures.
+        sys.modules.pop(spec.name, None)
+        raise
     return module
 
 
@@ -170,12 +176,12 @@ CHECKBOX_REGEX = re.compile(r"^\[([ xX])\]\s*(.*)$")
 VERIFY_HINT_REGEX = re.compile(r"\(verify:\s*([^\n)]+)\)", re.IGNORECASE)
 SAFE_VERIFY_COMMAND_RE = re.compile(
     r"^(?:"
-    r"(?:python(?:3)?\s+-m\s+)?pytest\b"
+    r"(?:python(?:3)?\s+-m\s+)?(?:pytest|unittest)\b"
     r"|node\s+--test\b"
     r"|(?:npm|pnpm|yarn)\s+(?:run\s+)?(?:test|vitest|jest|playwright)\b"
     r"|(?:make|just|cargo|go|dotnet)\s+(?:test|check)\b"
-    r"|gh\s+(?:workflow\s+run|run)\b"
-    r"|curl\s+\S+"
+    r"|gh\s+(?:workflow\s+run|run)\s+\S+"
+    r"|curl\s+https?://\S+\Z"
     r")",
     re.IGNORECASE,
 )
@@ -464,7 +470,7 @@ _DETAILS_TAG_RE = re.compile(r"</?details\b[^>]*>", re.IGNORECASE)
 # being wrapped again.
 _ORIGINAL_ISSUE_INNER_RE = re.compile(
     r"<details\b[^>]*>\s*<summary>Original Issue</summary>\s*"
-    r"(?P<fence>`{3,})text\n(?P<inner>.*?)\n(?P=fence)\s*</details>",
+    r"(?P<fence>`{3,}|~{3,})text\n(?P<inner>.*?)\n(?P=fence)\s*</details>",
     re.DOTALL | re.IGNORECASE,
 )
 
@@ -477,10 +483,38 @@ def _strip_original_issue_blocks(text: str) -> str:
         kept.append(text[cursor : match.start()])
         depth = 1
         end = match.end()
+        fence: tuple[str, int] | None = None
         for tag in _DETAILS_TAG_RE.finditer(text, match.end()):
+            # Literal HTML in the verbatim Original-Issue fence is content, not
+            # structural markup.  Only count tags outside Markdown fences.
+            # Include the tag itself while deciding whether this line is a
+            # marker-only closing fence.  A same-line ``</details>`` is
+            # fenced content, so it must keep the fence open rather than be
+            # counted as structural markup.
+            before = text[end : tag.end()]
+            for line in before.splitlines():
+                fence_match = re.match(r"\s{0,3}(`{3,}|~{3,})", line)
+                if not fence_match:
+                    continue
+                marker = fence_match.group(1)
+                if fence is None:
+                    fence = (marker[0], len(marker))
+                elif (
+                    marker[0] == fence[0]
+                    and len(marker) >= fence[1]
+                    and re.fullmatch(
+                        rf"\s{{0,3}}(?:`{{{fence[1]},}}|~{{{fence[1]},}})\s*",
+                        line,
+                    )
+                ):
+                    # Closing fences are marker-only; language tags / trailing
+                    # text must not toggle the fence state.
+                    fence = None
+            end = tag.end()
+            if fence is not None:
+                continue
             depth += -1 if tag.group(0).startswith("</") else 1
             if depth == 0:
-                end = tag.end()
                 break
         else:
             # Leave malformed markup intact rather than silently discarding it.
@@ -830,12 +864,15 @@ def main() -> None:
 
     if args.json:
         payload = {
-            "formatted_body": result["formatted_body"],
+            "formatted_body": result.get("formatted_body"),
             "provider_used": result.get("provider_used"),
             "used_llm": result.get("used_llm", False),
             "labels": build_label_transition(),
             "needs_refinement": result.get("needs_refinement", False),
+            "validation_audit": result.get("validation_audit"),
         }
+        if result.get("error"):
+            payload["error"] = result["error"]
         if result.get("guard_blocked"):
             payload["guard_blocked"] = True
             payload["guard_reason"] = result.get("guard_reason") or ""


### PR DESCRIPTION
## Sync Summary

### Files Updated
- agents-issue-intake.yml: Issue intake - processes new issues for agent assignment
- agents-issue-format-guard.yml: Issue format guard - validates issues on open/edit/reopen, hold/exemption-label changes, and manual dispatch against AGENT_ISSUE_FORMAT, while durable/wontfix and bot issues remain exempt. Pause and needs-human labels hold dispatch. Any invalid non-exempt issue change on those triggers clears stale agents:formatted state, and hold removal revalidates on resume. Non-conforming unheld work gets agents:format so the optimizer repairs it. Requires .github/scripts/issue_format.py.
- agents-auto-pilot.yml: Auto-pilot - end-to-end automation orchestrator (format → optimize → agent → verify)
- issue_format.py: Pure-stdlib validator for AGENT_ISSUE_FORMAT compliance. Single fleet definition of agent-processable; used by agents-issue-format-guard.yml and callable directly by local filers to pre-flight before gh issue create (non-zero exit = unfit). Do not fork per repo.
- check_deliberate_break.py: Opt-in Gate helper that proves named deliberate-break acceptance tests fail against the base implementation
- source_context.js: Classifies PR workflow source context for issue, local, automation, sync, Dependabot, review follow-up, and direct GitHub work
- issue_formatter.py: Issue formatter - converts raw text to AGENT_ISSUE_TEMPLATE format

### Files Skipped
- renovate.json: File exists and sync_mode is create_only
- cross-repo-smoke.yml: File exists and sync_mode is create_only
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Source SHA:** `e6b4733f0acad6f95d4ffc5fed73cd9ce1e1440b`
**Template hash:** `fc7701cf51e5`
**Consumer-sync plan ID:** `sha256:fc7701cf51e5c1d02cfb4452d73f634d7b8ad497a0919534ece23a6330d74035`
**Sync phase:** `canary`
**Sync branch:** `sync/workflows-fc7701cf51e5`
**Consumer repo:** `stranske/Template`
**Manifest:** `.github/sync-manifest.yml`

<!-- workflows-consumer-sync:v1 {"schema":"workflows-consumer-sync-pr/v1","consumer_repo":"stranske/Template","source_repository":"stranske/Workflows","source_sha":"e6b4733f0acad6f95d4ffc5fed73cd9ce1e1440b","template_hash":"fc7701cf51e5","plan_id":"sha256:fc7701cf51e5c1d02cfb4452d73f634d7b8ad497a0919534ece23a6330d74035","sync_phase":"canary","sync_branch":"sync/workflows-fc7701cf51e5","manifest":".github/sync-manifest.yml","lifecycle_state":"opened","run_id":"31346894654","run_attempt":"1","changes_count":7} -->
<!-- sync-pr-delivery-record:v1 {"schema":"sync-pr-delivery-record/v1","durable_issue_url":"https://github.com/stranske/Workflows/issues/1836","plan_id":"sha256:fc7701cf51e5c1d02cfb4452d73f634d7b8ad497a0919534ece23a6330d74035","generation":"fc7701cf51e5","repository":"stranske/Template","desired_tree_hash":"794306b2a04b75f71d209cca0f3706f2cb0e76dd","source_commit":"e6b4733f0acad6f95d4ffc5fed73cd9ce1e1440b","lease_expires_at":"2026-08-13T01:22:41Z","predecessor_prs":[],"successor_prs":[]} -->